### PR TITLE
Update SwiftPM file to 5.0.

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,5 +1,16 @@
+// swift-tools-version:5.0
 import PackageDescription
 
 let package = Package(
-    name: "CollectionViewSlantedLayout"
+    name: "CollectionViewSlantedLayout",
+    platforms: [
+        .iOS(.v9)
+    ],
+    products: [
+        .library(name: "CollectionViewSlantedLayout", targets: ["CollectionViewSlantedLayout"])
+    ],
+    targets: [
+        .target(name: "CollectionViewSlantedLayout", path: "Sources"),
+        .testTarget(name: "CollectionViewSlantedLayoutTests", dependencies: ["CollectionViewSlantedLayout"] , path: "Tests")
+    ]
 )

--- a/Sources/Extensions/CAShapeLayer+Helpers.swift
+++ b/Sources/Extensions/CAShapeLayer+Helpers.swift
@@ -23,6 +23,7 @@
  */
 
 import QuartzCore
+import UIKit
 
 /// :nodoc:
 extension CAShapeLayer {


### PR DESCRIPTION
Fix compilation issue by adding import for `UIBezierPath`

This allow to open project in Xcode 11 by opening Package.swift
To have build and test available

Using command line, build could be checked by executing
```sh
sdk=`xcrun -sdk iphonesimulator -show-sdk-path`
sdkVersion=`echo $sdk | sed -E 's/.*iPhoneSimulator(.*)\.sdk/\1/'`
swift build  -Xswiftc "-sdk" -Xswiftc "$sdk" -Xswiftc "-target" -Xswiftc "x86_64-apple-ios$sdkVersion-simulator"
```
could be added to a CI like travis or github workflow like [this](https://github.com/IBAnimatable/IBAnimatable/blob/master/.github/workflows/build.yml)