### PR TITLE
Layout attributes were received from the layout but are not valid for the data source counts. Attributes will be ignored.

### DIFF
--- a/Sources/CollectionViewSlantedLayout.swift
+++ b/Sources/CollectionViewSlantedLayout.swift
@@ -289,5 +289,11 @@ extension CollectionViewSlantedLayout {
     override open func layoutAttributesForItem(at indexPath: IndexPath) -> CollectionViewSlantedLayoutAttributes? {
         return cachedAttributes[indexPath.item]
     }
+ 
+    /// :nodoc:
+    override open func invalidateLayout() {
+        super.invalidateLayout()
+        self.cachedAttributes.removeAll()
+    }
 
 }


### PR DESCRIPTION
Related to issue #47.